### PR TITLE
Remove version number from galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,4 +6,3 @@ name: eos
 namespace: arista
 readme: README.rst
 repository: https://github.com/ansible-network/ansible_collections.arista.eos
-version: 0.0.1


### PR DESCRIPTION
This is dynamically generated by our release scripts now, based on git
information.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>